### PR TITLE
tre3calte: update baseband modem

### DIFF
--- a/rootdir/etc/init.baseband.rc
+++ b/rootdir/etc/init.baseband.rc
@@ -34,7 +34,7 @@ on early-boot
     write /proc/sys/net/core/wmem_max 2097152		
 
 # CP Boot Daemon (CBD)
-service cpboot-daemon /vendor/bin/hw/cbd -d -t ss300 -b s -m l -p 13
+service cpboot-daemon /vendor/bin/hw/cbd -d -t ss333 -b s -m l -p 13
     class main
     user root
     group radio cache inet misc audio sdcard_rw log sdcard_r shell


### PR DESCRIPTION
tre3calteskt uses ss333, while trelteskt and tbelteskt uses ss300

I'm building roms with this change on my server to test. so it will remains draft until it works